### PR TITLE
Fixed issue where preprocessing produced strange # of examples

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,7 +27,7 @@ TRAIN:
   CLASS_MODE: 'binary'                                    # One of {'binary', 'multiclass'}
   CLASS_MULTIPLIER: [0.15, 1.0]                           # Class multiplier for binary classification
   #CLASS_MULTIPLIER: [0.4, 1.0, 0.4]                      # Class multiplier for multiclass classification (3 classes)
-  EXPERIMENT_TYPE: 'multi_train'                          # One of {'single_train', 'multi_train', 'hparam_search'}
+  EXPERIMENT_TYPE: 'single_train'                         # One of {'single_train', 'multi_train', 'hparam_search'}
   BATCH_SIZE: 16
   EPOCHS: 200
   THRESHOLDS: 0.5                                         # Can be changed to list of values in range [0, 1]

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -40,15 +40,14 @@ def build_dataset(cfg):
     pa_normal_idxs = []
     for df_idx in rsna_normal_df.index.values.tolist():
         filename = rsna_normal_df.loc[df_idx]['patientId']
-        if not os.path.exists(other_data_path + filename + '.jpg'):
-            ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
-            if ds.SeriesDescription.split(' ')[1] == 'PA':
-                pixel_arr = ds.pixel_array
-                cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
-                pa_normal_idxs.append(df_idx)
-                pa_file_counter += 1
-            if pa_file_counter >= num_rsna_imgs // 2:
-                break
+        ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
+        if ds.SeriesDescription.split(' ')[1] == 'PA':
+            pixel_arr = ds.pixel_array
+            cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
+            pa_normal_idxs.append(df_idx)
+            pa_file_counter += 1
+        if pa_file_counter >= num_rsna_imgs // 2:
+            break
     rsna_normal_df = rsna_normal_df.loc[pa_normal_idxs]
 
     # Convert dicom files of CXRs with pneumonia to jpg if not done already in a previous run. Select only PA views.
@@ -57,15 +56,14 @@ def build_dataset(cfg):
     num_remaining = num_rsna_imgs - num_rsna_imgs // 2
     for df_idx in rsna_pneum_df.index.values.tolist():
         filename = rsna_pneum_df.loc[df_idx]['patientId']
-        if not os.path.exists(other_data_path + filename + '.jpg'):
-            ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
-            if ds.SeriesDescription.split(' ')[1] == 'PA':
-                pixel_arr = ds.pixel_array
-                cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
-                pa_pneum_idxs.append(df_idx)
-                pa_file_counter += 1
-            if pa_file_counter >= num_remaining:
-                break
+        ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
+        if ds.SeriesDescription.split(' ')[1] == 'PA':
+            pixel_arr = ds.pixel_array
+            cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
+            pa_pneum_idxs.append(df_idx)
+            pa_file_counter += 1
+        if pa_file_counter >= num_remaining:
+            break
     rsna_pneum_df = rsna_pneum_df.loc[pa_pneum_idxs]
 
     mode = cfg['TRAIN']['CLASS_MODE']


### PR DESCRIPTION
Occasionally, preprocessing was producing datasets with strange amounts of examples. This was found to be due to old behaviour whereby jpg representations of RSNA dicom images were not being overwritten, and thus not added to the dataframe of examples.