### PR TITLE
Addition of Figure 1 dataset and other preprocessing modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,11 @@ goals. A summary of the major configurable elements in this file is
 below.
 
 #### PATHS
-- **RAW_COVID_DATA**: Path to folder containing
-  [COVID-19 image dataset](https://github.com/ieee8023/covid-chestxray-dataset)
-- **RAW_OTHER_DATA**: Path to folder containing
+- **MILA_DATA**: Path to folder containing
+  [Mila COVID-19 image dataset](https://github.com/ieee8023/covid-chestxray-dataset)
+- **FIGURE1_DATA**: Path to folder containing
+  [Figure 1 image dataset](https://github.com/agchung/Figure1-COVID-chestxray-dataset)
+- **RSNA_DATA**: Path to folder containing
   [RSNA Pneumonia Detection Challenge dataset](https://www.kaggle.com/c/rsna-pneumonia-detection-challenge)
 - **MODEL_WEIGHTS**: Path at which to save trained model's weights
 - **MODEL_TO_LOAD**: Path to the trained model's weights that you would
@@ -400,9 +402,8 @@ below.
 - **IMG_DIM**: Desired target size of image after preprocessing
 - **VAL_SPLIT**: Fraction of the data allocated to the validation set
 - **TEST_SPLIT**: Fraction of the data allocated to the test set
-- **KAGGLE_DATA_FRAC**: Fraction of the images from the RSNA Kaggle
-  chest X-ray dataset to use. The default value results in a dataset of
-  about 1000 images total.
+- **NUM_RSNA_IMGS**: Number of images from the RSNA dataset that you wish
+  to include in your assembled dataset
 - **CLASSES**: This is an ordered list of class names. Must be the same
   length as the number of classes you wish to distinguish.
 #### TRAIN

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ below.
   explanations
 #### DATA
 - **IMG_DIM**: Desired target size of image after preprocessing
+- **VIEWS**: List of types of chest X-ray views to include. By default,
+  posteroanterior and anteroposterior views are included.
 - **VAL_SPLIT**: Fraction of the data allocated to the validation set
 - **TEST_SPLIT**: Fraction of the data allocated to the test set
 - **NUM_RSNA_IMGS**: Number of images from the RSNA dataset that you wish

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 PATHS:
-  RAW_COVID_DATA: 'D:/Documents/Work/covid-cxr/data/covid-chestxray-dataset/'   # Path of extracted COVID dataset https://github.com/ieee8023/covid-chestxray-dataset
-  RAW_OTHER_DATA: 'D:/Documents/Work/covid-cxr/data/rsna/'                      # Path of extracted NIH dataset https://www.kaggle.com/c/rsna-pneumonia-detection-challenge
+  MILA_DATA: 'D:/Documents/Work/covid-cxr/data/covid-chestxray-dataset/'              # Path of Mila dataset https://github.com/ieee8023/covid-chestxray-dataset
+  FIGURE1_DATA: 'D:/Documents/Work/covid-cxr/data/Figure1-COVID-chestxray-dataset/'   # Path of Figure 1 dataset https://github.com/agchung/Figure1-COVID-chestxray-dataset
+  RSNA_DATA: 'D:/Documents/Work/covid-cxr/data/rsna/'                                 # Path of RSNA dataset https://www.kaggle.com/c/rsna-pneumonia-detection-challenge
   PROCESSED_DATA: 'data/processed/'
   TRAIN_IMGS: 'data/processed/train/'
   VAL_IMGS: 'data/processed/val/'
@@ -21,8 +22,7 @@ DATA:
   IMG_DIM: [224, 224]
   VAL_SPLIT: 0.08
   TEST_SPLIT: 0.1
-  KAGGLE_DATA_FRAC: 0.2
-  NUM_RSNA_IMGS: 907
+  NUM_RSNA_IMGS: 1000
   CLASSES: ['non-COVID-19', 'COVID-19']                   # Classes for binary classification
   #CLASSES: ['normal', 'COVID-19', 'other_pneumonia']     # Classes for multiclass classification (3 classes)
 

--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,7 @@ PATHS:
 
 DATA:
   IMG_DIM: [224, 224]
+  VIEWS: ['PA', 'AP', nan]
   VAL_SPLIT: 0.08
   TEST_SPLIT: 0.1
   NUM_RSNA_IMGS: 1000

--- a/config.yml
+++ b/config.yml
@@ -3,9 +3,6 @@ PATHS:
   FIGURE1_DATA: 'D:/Documents/Work/covid-cxr/data/Figure1-COVID-chestxray-dataset/'   # Path of Figure 1 dataset https://github.com/agchung/Figure1-COVID-chestxray-dataset
   RSNA_DATA: 'D:/Documents/Work/covid-cxr/data/rsna/'                                 # Path of RSNA dataset https://www.kaggle.com/c/rsna-pneumonia-detection-challenge
   PROCESSED_DATA: 'data/processed/'
-  TRAIN_IMGS: 'data/processed/train/'
-  VAL_IMGS: 'data/processed/val/'
-  TEST_IMGS: 'data/processed/test/'
   TRAIN_SET: 'data/processed/train_set.csv'
   VAL_SET: 'data/processed/val_set.csv'
   TEST_SET: 'data/processed/test_set.csv'
@@ -20,7 +17,7 @@ PATHS:
 
 DATA:
   IMG_DIM: [224, 224]
-  VIEWS: ['PA', 'AP', nan]
+  VIEWS: ['PA', 'AP']
   VAL_SPLIT: 0.08
   TEST_SPLIT: 0.1
   NUM_RSNA_IMGS: 1000

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -19,17 +19,26 @@ def build_dataset(cfg):
     '''
 
     # Get paths of raw datasets to be included
-    covid_data_path = cfg['PATHS']['RAW_COVID_DATA']
-    other_data_path = cfg['PATHS']['RAW_OTHER_DATA']
+    mila_data_path = cfg['PATHS']['MILA_DATA']
+    fig1_data_path = cfg['PATHS']['FIGURE1_DATA']
+    rsna_data_path = cfg['PATHS']['RSNA_DATA']
 
-    # Assemble filenames comprising COVID dataset
-    metadata_file_path = covid_data_path + 'metadata.csv'
-    covid_df = pd.read_csv(metadata_file_path)
-    covid_PA_cxrs_df = (covid_df['view'] == 'PA')
-    covid_patients_df = (covid_df['finding'] == 'COVID-19')
+    # Assemble filenames comprising Mila dataset
+    mila_df = pd.read_csv(mila_data_path + 'metadata.csv')
+    mila_df['filename'] = mila_data_path + 'images/' + mila_df['filename'].astype(str)
+    mila_PA_cxrs_df = (mila_df['view'] == 'PA')
+    mila_covid_pts_df = (mila_df['finding'] == 'COVID-19')
+    mila_covid_PA_df = mila_df[mila_covid_pts_df & mila_PA_cxrs_df]  # PA images for patients diagnosed COVID-19
+
+    # Assemble filenames comprising Figure 1 dataset
+    fig1_df = pd.read_csv(fig1_data_path + 'metadata.csv', encoding='ISO-8859-1')
+    fig1_df['filename'] = fig1_data_path + 'images/' + fig1_df['patientid'].astype(str) + '.jpg'
+    fig1_PA_cxrs_df = (fig1_df['view'] == 'PA')
+    fig1_covid_pts_df = (fig1_df['finding'] == 'COVID-19')
+    fig1_covid_PA_df = fig1_df[fig1_covid_pts_df & fig1_PA_cxrs_df]  # PA images for patients diagnosed COVID-19
 
     # Assemble filenames comprising RSNA dataset
-    rsna_metadata_path = other_data_path + 'stage_2_train_labels.csv'
+    rsna_metadata_path = rsna_data_path + 'stage_2_train_labels.csv'
     rsna_df = pd.read_csv(rsna_metadata_path)
     num_rsna_imgs = cfg['DATA']['NUM_RSNA_IMGS']
     rsna_normal_df = rsna_df[rsna_df['Target'] == 0]
@@ -40,10 +49,10 @@ def build_dataset(cfg):
     pa_normal_idxs = []
     for df_idx in rsna_normal_df.index.values.tolist():
         filename = rsna_normal_df.loc[df_idx]['patientId']
-        ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
+        ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
         if ds.SeriesDescription.split(' ')[1] == 'PA':
-            pixel_arr = ds.pixel_array
-            cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
+            if not os.path.exists(rsna_data_path + filename + '.jpg'):
+                cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)
             pa_normal_idxs.append(df_idx)
             pa_file_counter += 1
         if pa_file_counter >= num_rsna_imgs // 2:
@@ -56,10 +65,10 @@ def build_dataset(cfg):
     num_remaining = num_rsna_imgs - num_rsna_imgs // 2
     for df_idx in rsna_pneum_df.index.values.tolist():
         filename = rsna_pneum_df.loc[df_idx]['patientId']
-        ds = dicom.dcmread(os.path.join(other_data_path + 'stage_2_train_images/' + filename + '.dcm'))
+        ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
         if ds.SeriesDescription.split(' ')[1] == 'PA':
             pixel_arr = ds.pixel_array
-            cv2.imwrite(os.path.join(other_data_path + filename + '.jpg'), pixel_arr)
+            cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), pixel_arr)
             pa_pneum_idxs.append(df_idx)
             pa_file_counter += 1
         if pa_file_counter >= num_remaining:
@@ -72,29 +81,32 @@ def build_dataset(cfg):
     label_dict = {i: cfg['DATA']['CLASSES'][i] for i in range(n_classes)}  # Map class name to number
 
     if mode == 'binary':
-        PA_covid_df = covid_df[covid_patients_df & covid_PA_cxrs_df]      # PA images diagnosed COVID
-        PA_covid_df['label'] = 1
-        PA_other_df = covid_df[~covid_patients_df & covid_PA_cxrs_df]     # PA images with other diagnoses
-        PA_other_df['label'] = 0
-        file_df = pd.concat([PA_covid_df[['filename', 'label']], PA_other_df[['filename', 'label']]], axis=0)
-        file_df['filename'] = covid_data_path + 'images/' + file_df['filename'].astype(str)    # Set as absolute paths
+        mila_covid_PA_df['label'] = 1                                       # Mila images with COVID-19 diagnosis
+        mila_other_PA_df = mila_df[~mila_covid_pts_df & mila_PA_cxrs_df]
+        mila_other_PA_df['label'] = 0                                       # Mila images with alternative diagnoses
+        fig1_covid_PA_df['label'] = 1                                       # Figure 1 images with COVID-19 diagnosis
+        file_df = pd.concat([mila_covid_PA_df[['filename', 'label']], mila_other_PA_df[['filename', 'label']],
+                             fig1_covid_PA_df[['filename', 'label']]], axis=0)
 
         rsna_df = pd.concat([rsna_normal_df, rsna_pneum_df], axis=0)
-        rsna_filenames = other_data_path + rsna_df['patientId'].astype(str) + '.jpg'
+        rsna_filenames = rsna_data_path + rsna_df['patientId'].astype(str) + '.jpg'
         rsna_file_df = pd.DataFrame({'filename': rsna_filenames, 'label': 0})
 
         file_df = pd.concat([file_df, rsna_file_df], axis=0)         # Combine both datasets
     else:
-        PA_covid_df = covid_df[covid_patients_df & covid_PA_cxrs_df]  # PA images diagnosed COVID
-        PA_covid_df['label'] = class_dict['COVID-19']
-        PA_pneum_df = covid_df[covid_df['finding'].isin(['SARS', 'Steptococcus']) & covid_PA_cxrs_df]   # PA images diagnosed with SARS
-        PA_pneum_df['label'] = class_dict['other_pneumonia']                 # Classify SARS with other viral pneumonias
-        file_df = pd.concat([PA_covid_df[['filename', 'label']], PA_pneum_df[['filename', 'label']]], axis=0)
-        file_df['filename'] = covid_data_path + 'images/' + file_df['filename'].astype(str)  # Set as absolute paths
+        mila_covid_PA_df['label'] = class_dict['COVID-19']
+        mila_PA_pneum_df = mila_df[mila_df['finding'].isin(['SARS', 'Steptococcus', 'MERS', 'Legionella', 'Klebsiella',
+                                                            'Chlamydophila', 'Pneumocystis']) & mila_PA_cxrs_df]
+        mila_PA_pneum_df['label'] = class_dict['other_pneumonia']                 # Mila CXRs with other peumonias
+        mila_PA_normal_df = mila_df[mila_df['finding'].isin(['No finding']) & mila_PA_cxrs_df]
+        mila_PA_normal_df['label'] = class_dict['normal']                         # Mila CXRs with no finding
+        fig1_covid_PA_df['label'] = class_dict['COVID-19']                        # Figure 1 CXRs with COVID-19 finding
+        file_df = pd.concat([mila_covid_PA_df[['filename', 'label']], mila_PA_pneum_df[['filename', 'label']],
+                             mila_PA_normal_df[['filename', 'label']], fig1_covid_PA_df[['filename', 'label']]], axis=0)
 
         # Organize some files from RSNA dataset into "normal", and "pneumonia" XRs
-        rsna_normal_filenames = other_data_path + rsna_normal_df['patientId'].astype(str) + '.jpg'
-        rsna_pneum_filenames = other_data_path + rsna_pneum_df['patientId'].astype(str) + '.jpg'
+        rsna_normal_filenames = rsna_data_path + rsna_normal_df['patientId'].astype(str) + '.jpg'
+        rsna_pneum_filenames = rsna_data_path + rsna_pneum_df['patientId'].astype(str) + '.jpg'
         rsna_normal_file_df = pd.DataFrame({'filename': rsna_normal_filenames, 'label': class_dict['normal']})
         rsna_pneum_file_df = pd.DataFrame({'filename': rsna_pneum_filenames, 'label': class_dict['other_pneumonia']})
         rsna_file_df = pd.concat([rsna_normal_file_df, rsna_pneum_file_df], axis=0)

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -57,7 +57,6 @@ def build_dataset(cfg):
         ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
         if any(view in ds.SeriesDescription.split(' ')[1] for view in cfg['DATA']['VIEWS']):  # Select desired X-ray views
             if not os.path.exists(rsna_data_path + filename + '.jpg'):
-                print('normal file written')
                 cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)   # Save as .jpg
             normal_idxs.append(df_idx)
             file_counter += 1
@@ -74,7 +73,6 @@ def build_dataset(cfg):
         ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
         if any(view in ds.SeriesDescription.split(' ')[1] for view in cfg['DATA']['VIEWS']):  # Select desired X-ray views
             if not os.path.exists(rsna_data_path + filename + '.jpg'):
-                print('pneumonia file written')
                 cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)  # Save as .jpg
             pneum_idxs.append(df_idx)
             file_counter += 1
@@ -145,7 +143,6 @@ def preprocess():
     '''
 
     cfg = yaml.full_load(open(os.getcwd() + "/config.yml", 'r'))  # Load config data
-    processed_path = cfg['PATHS']['PROCESSED_DATA']
 
     # Build dataset based on type of classification
     file_df = build_dataset(cfg)
@@ -157,35 +154,6 @@ def preprocess():
     relative_val_split = val_split / (1 - test_split)  # Calculate fraction of train_df to be used for validation
     file_df_train, file_df_val = train_test_split(file_df_train, test_size=relative_val_split,
                                                       stratify=file_df_train['label'])
-
-    # Delete old datasets
-    dest_dir = os.path.join(os.getcwd(), processed_path)
-    print('Deleting old sets.')
-    for path in pathlib.Path(os.path.join(dest_dir, 'train/')).glob('*'):
-        if '.gitkeep' not in str(path):
-            path.unlink()
-    for path in pathlib.Path(os.path.join(dest_dir, 'val/')).glob('*'):
-        if '.gitkeep' not in str(path):
-            path.unlink()
-    for path in pathlib.Path(os.path.join(dest_dir, 'test/')).glob('*'):
-        if '.gitkeep' not in str(path):
-            path.unlink()
-
-    # Copy images to appropriate directories
-    print('Copying training set images.')
-    for file_path in tqdm(file_df_train['filename'].tolist()):
-        shutil.copy(file_path, os.path.join(dest_dir, 'train/'))
-    print('Copying validation set images.')
-    for file_path in tqdm(file_df_val['filename'].tolist()):
-        shutil.copy(file_path, os.path.join(dest_dir, 'val/'))
-    print('Copying test set images.')
-    for file_path in tqdm(file_df_test['filename'].tolist()):
-        shutil.copy(file_path, os.path.join(dest_dir, 'test/'))
-
-    # Update file path dataframes
-    file_df_train['filename'] = file_df_train['filename'].str.split('/').str[-1]
-    file_df_val['filename'] = file_df_val['filename'].str.split('/').str[-1]
-    file_df_test['filename'] = file_df_test['filename'].str.split('/').str[-1]
 
     # Save training, validation and test sets
     file_df_train.to_csv(cfg['PATHS']['TRAIN_SET'])

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -6,7 +6,6 @@ import os
 import pathlib
 import shutil
 import cv2
-from math import ceil
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
@@ -26,16 +25,22 @@ def build_dataset(cfg):
     # Assemble filenames comprising Mila dataset
     mila_df = pd.read_csv(mila_data_path + 'metadata.csv')
     mila_df['filename'] = mila_data_path + 'images/' + mila_df['filename'].astype(str)
-    mila_PA_cxrs_df = (mila_df['view'] == 'PA')
+    mila_views_cxrs_df = (mila_df['view'].str.contains('|'.join(cfg['DATA']['VIEWS'])))    # Select desired X-ray views
     mila_covid_pts_df = (mila_df['finding'] == 'COVID-19')
-    mila_covid_PA_df = mila_df[mila_covid_pts_df & mila_PA_cxrs_df]  # PA images for patients diagnosed COVID-19
+    mila_covid_views_df = mila_df[mila_covid_pts_df & mila_views_cxrs_df]  # Images for patients diagnosed with COVID-19
 
     # Assemble filenames comprising Figure 1 dataset
     fig1_df = pd.read_csv(fig1_data_path + 'metadata.csv', encoding='ISO-8859-1')
-    fig1_df['filename'] = fig1_data_path + 'images/' + fig1_df['patientid'].astype(str) + '.jpg'
-    fig1_PA_cxrs_df = (fig1_df['view'] == 'PA')
+    fig1_df['filename'] = ''
+    for i, row in fig1_df.iterrows():
+        if os.path.exists(fig1_data_path + 'images/' + fig1_df.loc[i, 'patientid'] + '.jpg'):
+            fig1_df.loc[i, 'filename'] = fig1_data_path + 'images/' + fig1_df.loc[i, 'patientid'] + '.jpg'
+        else:
+            fig1_df.loc[i, 'filename'] = fig1_data_path + 'images/' + fig1_df.loc[i, 'patientid'] + '.png'
+    fig1_df['view'].fillna('PA or AP', inplace=True)    # All images in this dataset are either AP or PA
+    fig1_views_cxrs_df = (fig1_df['view'].str.contains('|'.join(cfg['DATA']['VIEWS'])))    # Select desired X-ray views
     fig1_covid_pts_df = (fig1_df['finding'] == 'COVID-19')
-    fig1_covid_PA_df = fig1_df[fig1_covid_pts_df & fig1_PA_cxrs_df]  # PA images for patients diagnosed COVID-19
+    fig1_covid_views_df = fig1_df[fig1_covid_pts_df & fig1_views_cxrs_df]  # Images for patients diagnosed COVID-19
 
     # Assemble filenames comprising RSNA dataset
     rsna_metadata_path = rsna_data_path + 'stage_2_train_labels.csv'
@@ -44,36 +49,38 @@ def build_dataset(cfg):
     rsna_normal_df = rsna_df[rsna_df['Target'] == 0]
     rsna_pneum_df = rsna_df[rsna_df['Target'] == 1]
 
-    # Convert dicom files of CXRs with no findings to jpg if not done already in a previous run. Select only PA views.
-    pa_file_counter = 0
-    pa_normal_idxs = []
+    # Convert dicom files of CXRs with no findings to jpg if not done already in a previous run. Select desired views.
+    file_counter = 0
+    normal_idxs = []
     for df_idx in rsna_normal_df.index.values.tolist():
         filename = rsna_normal_df.loc[df_idx]['patientId']
         ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
-        if ds.SeriesDescription.split(' ')[1] == 'PA':
+        if any(view in ds.SeriesDescription.split(' ')[1] for view in cfg['DATA']['VIEWS']):  # Select desired X-ray views
             if not os.path.exists(rsna_data_path + filename + '.jpg'):
-                cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)
-            pa_normal_idxs.append(df_idx)
-            pa_file_counter += 1
-        if pa_file_counter >= num_rsna_imgs // 2:
+                print('normal file written')
+                cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)   # Save as .jpg
+            normal_idxs.append(df_idx)
+            file_counter += 1
+        if file_counter >= num_rsna_imgs // 2:
             break
-    rsna_normal_df = rsna_normal_df.loc[pa_normal_idxs]
+    rsna_normal_df = rsna_normal_df.loc[normal_idxs]
 
-    # Convert dicom files of CXRs with pneumonia to jpg if not done already in a previous run. Select only PA views.
-    pa_file_counter = 0
-    pa_pneum_idxs = []
+    # Convert dicom files of CXRs with pneumonia to jpg if not done already in a previous run. Select desired views.
+    file_counter = 0
+    pneum_idxs = []
     num_remaining = num_rsna_imgs - num_rsna_imgs // 2
     for df_idx in rsna_pneum_df.index.values.tolist():
         filename = rsna_pneum_df.loc[df_idx]['patientId']
         ds = dicom.dcmread(os.path.join(rsna_data_path + 'stage_2_train_images/' + filename + '.dcm'))
-        if ds.SeriesDescription.split(' ')[1] == 'PA':
-            pixel_arr = ds.pixel_array
-            cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), pixel_arr)
-            pa_pneum_idxs.append(df_idx)
-            pa_file_counter += 1
-        if pa_file_counter >= num_remaining:
+        if any(view in ds.SeriesDescription.split(' ')[1] for view in cfg['DATA']['VIEWS']):  # Select desired X-ray views
+            if not os.path.exists(rsna_data_path + filename + '.jpg'):
+                print('pneumonia file written')
+                cv2.imwrite(os.path.join(rsna_data_path + filename + '.jpg'), ds.pixel_array)  # Save as .jpg
+            pneum_idxs.append(df_idx)
+            file_counter += 1
+        if file_counter >= num_remaining:
             break
-    rsna_pneum_df = rsna_pneum_df.loc[pa_pneum_idxs]
+    rsna_pneum_df = rsna_pneum_df.loc[pneum_idxs]
 
     mode = cfg['TRAIN']['CLASS_MODE']
     n_classes = len(cfg['DATA']['CLASSES'])
@@ -81,12 +88,12 @@ def build_dataset(cfg):
     label_dict = {i: cfg['DATA']['CLASSES'][i] for i in range(n_classes)}  # Map class name to number
 
     if mode == 'binary':
-        mila_covid_PA_df['label'] = 1                                       # Mila images with COVID-19 diagnosis
-        mila_other_PA_df = mila_df[~mila_covid_pts_df & mila_PA_cxrs_df]
-        mila_other_PA_df['label'] = 0                                       # Mila images with alternative diagnoses
-        fig1_covid_PA_df['label'] = 1                                       # Figure 1 images with COVID-19 diagnosis
-        file_df = pd.concat([mila_covid_PA_df[['filename', 'label']], mila_other_PA_df[['filename', 'label']],
-                             fig1_covid_PA_df[['filename', 'label']]], axis=0)
+        mila_covid_views_df['label'] = 1                                       # Mila images with COVID-19 diagnosis
+        mila_other_views_df = mila_df[~mila_covid_pts_df & mila_views_cxrs_df]
+        mila_other_views_df['label'] = 0                                       # Mila images with alternative diagnoses
+        fig1_covid_views_df['label'] = 1                                       # Figure 1 images with COVID-19 diagnosis
+        file_df = pd.concat([mila_covid_views_df[['filename', 'label']], mila_other_views_df[['filename', 'label']],
+                             fig1_covid_views_df[['filename', 'label']]], axis=0)
 
         rsna_df = pd.concat([rsna_normal_df, rsna_pneum_df], axis=0)
         rsna_filenames = rsna_data_path + rsna_df['patientId'].astype(str) + '.jpg'
@@ -94,15 +101,15 @@ def build_dataset(cfg):
 
         file_df = pd.concat([file_df, rsna_file_df], axis=0)         # Combine both datasets
     else:
-        mila_covid_PA_df['label'] = class_dict['COVID-19']
-        mila_PA_pneum_df = mila_df[mila_df['finding'].isin(['SARS', 'Steptococcus', 'MERS', 'Legionella', 'Klebsiella',
-                                                            'Chlamydophila', 'Pneumocystis']) & mila_PA_cxrs_df]
-        mila_PA_pneum_df['label'] = class_dict['other_pneumonia']                 # Mila CXRs with other peumonias
-        mila_PA_normal_df = mila_df[mila_df['finding'].isin(['No finding']) & mila_PA_cxrs_df]
-        mila_PA_normal_df['label'] = class_dict['normal']                         # Mila CXRs with no finding
-        fig1_covid_PA_df['label'] = class_dict['COVID-19']                        # Figure 1 CXRs with COVID-19 finding
-        file_df = pd.concat([mila_covid_PA_df[['filename', 'label']], mila_PA_pneum_df[['filename', 'label']],
-                             mila_PA_normal_df[['filename', 'label']], fig1_covid_PA_df[['filename', 'label']]], axis=0)
+        mila_covid_views_df['label'] = class_dict['COVID-19']
+        mila_views_pneum_df = mila_df[mila_df['finding'].isin(['SARS', 'Steptococcus', 'MERS', 'Legionella', 'Klebsiella',
+                                                            'Chlamydophila', 'Pneumocystis']) & mila_views_cxrs_df]
+        mila_views_pneum_df['label'] = class_dict['other_pneumonia']                 # Mila CXRs with other peumonias
+        mila_views_normal_df = mila_df[mila_df['finding'].isin(['No finding']) & mila_views_cxrs_df]
+        mila_views_normal_df['label'] = class_dict['normal']                         # Mila CXRs with no finding
+        fig1_covid_views_df['label'] = class_dict['COVID-19']                        # Figure 1 CXRs with COVID-19 finding
+        file_df = pd.concat([mila_covid_views_df[['filename', 'label']], mila_views_pneum_df[['filename', 'label']],
+                             mila_views_normal_df[['filename', 'label']], fig1_covid_views_df[['filename', 'label']]], axis=0)
 
         # Organize some files from RSNA dataset into "normal", and "pneumonia" XRs
         rsna_normal_filenames = rsna_data_path + rsna_normal_df['patientId'].astype(str) + '.jpg'
@@ -119,8 +126,8 @@ def build_dataset(cfg):
 
 def remove_text(img):
     '''
-    Attempts to remove textual artifacts from X-ray images. For example, many images indicate the right side of the
-    body with a white 'R'. Works only for very bright text.
+    Attempts to remove bright textual artifacts from X-ray images. For example, many images indicate the right side of
+    the body with a white 'R'. Works only for very bright text.
     :param img: Numpy array of image
     :return: Array of image with (ideally) any characters removed and inpainted
     '''

--- a/src/train.py
+++ b/src/train.py
@@ -80,11 +80,11 @@ def train_model(cfg, data, callbacks, verbose=1):
     img_shape = tuple(cfg['DATA']['IMG_DIM'])
     y_col = 'label_str'
     class_mode = 'categorical'
-    train_generator = train_img_gen.flow_from_dataframe(dataframe=data['TRAIN'], directory=cfg['PATHS']['TRAIN_IMGS'],
+    train_generator = train_img_gen.flow_from_dataframe(dataframe=data['TRAIN'], directory=None,
         x_col="filename", y_col=y_col, target_size=img_shape, batch_size=cfg['TRAIN']['BATCH_SIZE'], class_mode=class_mode)
-    val_generator = val_img_gen.flow_from_dataframe(dataframe=data['VAL'], directory=cfg['PATHS']['VAL_IMGS'],
+    val_generator = val_img_gen.flow_from_dataframe(dataframe=data['VAL'], directory=None,
         x_col="filename", y_col=y_col, target_size=img_shape, batch_size=cfg['TRAIN']['BATCH_SIZE'], class_mode=class_mode)
-    test_generator = test_img_gen.flow_from_dataframe(dataframe=data['TEST'], directory=cfg['PATHS']['TEST_IMGS'],
+    test_generator = test_img_gen.flow_from_dataframe(dataframe=data['TEST'], directory=None,
         x_col="filename", y_col=y_col, target_size=img_shape, batch_size=cfg['TRAIN']['BATCH_SIZE'], class_mode=class_mode,
         shuffle=False)
 


### PR DESCRIPTION
Preprocessing was modified to include images from the [Figure 1 dataset ](https://github.com/agchung/Figure1-COVID-chestxray-dataset). 

Other changes to preprocessing include:
- The ability to select which chest X-ray views to be included in the dataset (e.g. PA, AP)
- Images are no longer copied to separate train/test/validation folders in the _data/processed_ directory. Rather, absolute paths are stored in the CSV files describing the datasets and the files at the absolute paths are accessed during training.
