### PR TITLE
Fixed loading of test set images in interpretability scripts

### DIFF
--- a/src/interpretability/gradcam.py
+++ b/src/interpretability/gradcam.py
@@ -23,7 +23,6 @@ def setup_gradcam():
     setup_dict['MODEL'] = load_model(cfg['PATHS']['MODEL_TO_LOAD'], compile=False)
     print(setup_dict['MODEL'].summary())
     setup_dict['IMG_PATH'] = cfg['PATHS']['IMAGES']
-    setup_dict['TEST_IMG_PATH'] = cfg['PATHS']['TEST_IMGS']
     setup_dict['TEST_SET'] = pd.read_csv(cfg['PATHS']['TEST_SET'])
     setup_dict['IMG_DIM'] = cfg['DATA']['IMG_DIM']
     setup_dict['CLASSES'] = cfg['DATA']['CLASSES']
@@ -32,7 +31,7 @@ def setup_gradcam():
     test_img_gen = ImageDataGenerator(preprocessing_function=remove_text,
                                        samplewise_std_normalization=True, samplewise_center=True)
     test_generator = test_img_gen.flow_from_dataframe(dataframe=setup_dict['TEST_SET'],
-                                                      directory=cfg['PATHS']['TEST_IMGS'],
+                                                      directory=None,
                                                       x_col="filename", y_col='label_str',
                                                       target_size=tuple(cfg['DATA']['IMG_DIM']), batch_size=1,
                                                       class_mode='categorical', shuffle=False)
@@ -55,7 +54,7 @@ def apply_gradcam(setup_dict, idx, layer_name, hm_intensity=0.5, save_hm=True):
         x, y = setup_dict['TEST_GENERATOR'].next()
 
     # Get the corresponding original image (no preprocessing)
-    orig_img = cv2.imread(setup_dict['TEST_IMG_PATH'] + setup_dict['TEST_SET']['filename'][idx])
+    orig_img = cv2.imread(setup_dict['TEST_SET']['filename'][idx])
     new_dim = tuple(setup_dict['IMG_DIM'])
     orig_img = cv2.resize(orig_img, new_dim, interpolation=cv2.INTER_NEAREST)     # Resize image
 
@@ -89,10 +88,10 @@ def apply_gradcam(setup_dict, idx, layer_name, hm_intensity=0.5, save_hm=True):
     img_filename = setup_dict['TEST_SET']['filename'][idx]
     label = setup_dict['TEST_SET']['label'][idx]
     _ = visualize_heatmap(orig_img, heatmap_img, img_filename, label, probs, setup_dict['CLASSES'],
-                              file_path=file_path)
+                              dir_path=file_path)
     return
 
 if __name__ == '__main__':
     setup_dict = setup_gradcam()
-    apply_gradcam(setup_dict, 0, 'concatenate_2', hm_intensity=0.5, save_hm=False)    # Generate heatmap for image
+    apply_gradcam(setup_dict, 0, 'concatenate_2', hm_intensity=0.5, save_hm=True)    # Generate heatmap for image
 

--- a/src/interpretability/lime_explain.py
+++ b/src/interpretability/lime_explain.py
@@ -25,7 +25,6 @@ def setup_lime():
     lime_dict['NUM_SAMPLES'] = cfg['LIME']['NUM_SAMPLES']
     lime_dict['NUM_FEATURES'] = cfg['LIME']['NUM_FEATURES']
     lime_dict['IMG_PATH'] = cfg['PATHS']['IMAGES']
-    lime_dict['TEST_IMG_PATH'] = cfg['PATHS']['TEST_IMGS']
     lime_dict['IMG_DIM'] = cfg['DATA']['IMG_DIM']
     lime_dict['PRED_THRESHOLD'] = cfg['PREDICTION']['THRESHOLD']
     lime_dict['CLASSES'] = cfg['DATA']['CLASSES']
@@ -41,7 +40,7 @@ def setup_lime():
     # Create ImageDataGenerator for test set
     test_img_gen = ImageDataGenerator(preprocessing_function=remove_text,
                                        samplewise_std_normalization=True, samplewise_center=True)
-    test_generator = test_img_gen.flow_from_dataframe(dataframe=lime_dict['TEST_SET'], directory=cfg['PATHS']['TEST_IMGS'],
+    test_generator = test_img_gen.flow_from_dataframe(dataframe=lime_dict['TEST_SET'], directory=None,
         x_col="filename", y_col='label_str', target_size=tuple(cfg['DATA']['IMG_DIM']), batch_size=1,
         class_mode='categorical', shuffle=False)
     lime_dict['TEST_GENERATOR'] = test_generator
@@ -73,7 +72,7 @@ def explain_xray(lime_dict, idx, save_exp=True):
     x = np.squeeze(x, axis=0)
 
     # Get the corresponding original image (no preprocessing)
-    orig_img = cv2.imread(lime_dict['TEST_IMG_PATH'] + lime_dict['TEST_SET']['filename'][idx])
+    orig_img = cv2.imread(lime_dict['TEST_SET']['filename'][idx])
     new_dim = tuple(lime_dict['IMG_DIM'])
     orig_img = cv2.resize(orig_img, new_dim, interpolation=cv2.INTER_NEAREST)     # Resize image
 
@@ -101,7 +100,7 @@ def explain_xray(lime_dict, idx, save_exp=True):
     else:
         label_to_see = 'top'
     _ = visualize_explanation(orig_img, explanation, img_filename, label, probs, lime_dict['CLASSES'], label_to_see=label_to_see,
-                          file_path=file_path)
+                          dir_path=file_path)
     return
 
 

--- a/src/visualization/visualize.py
+++ b/src/visualization/visualize.py
@@ -160,7 +160,7 @@ def visualize_explanation(orig_img, explanation, img_filename, label, probs, cla
     fig.text(0.02, 0.82, "Predicted Class: " + str(pred_class) + ' (' + class_names[pred_class] + ')', fontsize=10)
     if label is not None:
         fig.text(0.02, 0.84, "Ground Truth Class: " + str(label) + ' (' + class_names[label] + ')', fontsize=10)
-    fig.suptitle("LIME Explanation for image " + img_filename, fontsize=15)
+    fig.suptitle("LIME Explanation for image " + img_filename, fontsize=13)
     fig.tight_layout()
 
     # Save the image
@@ -168,11 +168,11 @@ def visualize_explanation(orig_img, explanation, img_filename, label, probs, cla
     if dir_path is not None:
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
-        filename = dir_path + img_filename + '_exp_' + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '.png'
+        filename = dir_path + img_filename.split('/')[-1] + '_exp_' + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '.png'
         plt.savefig(filename)
     return filename
 
-def visualize_heatmap(orig_img, heatmap, img_filename, label, probs, class_names, file_path=None):
+def visualize_heatmap(orig_img, heatmap, img_filename, label, probs, class_names, dir_path=None):
     '''
     Obtain a comparison of an original image and heatmap produced by Grad-CAM.
     :param orig_img: Original X-Ray image
@@ -181,7 +181,7 @@ def visualize_heatmap(orig_img, heatmap, img_filename, label, probs, class_names
     :param label: Ground truth class of the example
     :param probs: Prediction probabilities
     :param class_names: Ordered list of class names
-    :param file_path: Path to save the generated image
+    :param dir_path: Path to save the generated image
     :return: Path to saved image
     '''
 
@@ -196,12 +196,12 @@ def visualize_heatmap(orig_img, heatmap, img_filename, label, probs, class_names
     fig.text(0.02, 0.82, "Predicted Class: " + str(pred_class) + ' (' + class_names[pred_class] + ')', fontsize=10)
     if label is not None:
         fig.text(0.02, 0.84, "Ground Truth Class: " + str(label) + ' (' + class_names[label] + ')', fontsize=10)
-    fig.suptitle("Grad-CAM heatmap for image " + img_filename, fontsize=15)
+    fig.suptitle("Grad-CAM heatmap for image " + img_filename, fontsize=13)
     fig.tight_layout()
 
     # Save the image
     filename = None
-    if file_path is not None:
-        filename = file_path + img_filename + '_gradcam_' + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '.png'
+    if dir_path is not None:
+        filename = dir_path + img_filename.split('/')[-1] + '_gradcam_' + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '.png'
         plt.savefig(filename)
     return filename


### PR DESCRIPTION
It came to our attention that recent preprocessing updates affected the loading of test set images in interpretability scripts (LIME and GradCAM). There were outdated references to test image folders. Due to recent updates in preprocessing, folders are no longer created for train/test/val sets. The scripts were updated to refer to the absolute image file path when loading a test set image.